### PR TITLE
Implement offline TFLite enhancer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     // build.gradle (app)
     implementation("org.tensorflow:tensorflow-lite:2.14.0")
+    implementation("org.tensorflow:tensorflow-lite-select-tf-ops:2.14.0")
     implementation("org.tensorflow:tensorflow-lite-support:0.4.3")
     implementation("org.tensorflow:tensorflow-lite-task-text:0.4.3")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("org.tensorflow:tensorflow-lite-select-tf-ops:2.14.0")
     implementation("org.tensorflow:tensorflow-lite-support:0.4.3")
     implementation("org.tensorflow:tensorflow-lite-task-text:0.4.3")
+    implementation("ai.djl.huggingface:tokenizers:0.33.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
+++ b/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
@@ -49,7 +49,7 @@ class TextEnhancer {
                     }
                     interpreter = Interpreter(mapped, options)
                     context.assets.open(TOKENIZER_FILE).use { stream ->
-                        tokenizer = HuggingFaceTokenizer.newInstance(stream, emptyMap())
+                        tokenizer = HuggingFaceTokenizer.newInstance(stream, emptyMap<String, Any>())
                     }
                     startToken = tokenizer.encode("<pad>").ids.first().toLong()
                     endToken = tokenizer.encode("</s>").ids.first().toLong()
@@ -80,7 +80,6 @@ class TextEnhancer {
             val encoding = tokenizer.encode(originalText)
             val inputIds = encoding.ids
             val attention = LongArray(inputIds.size) { 1L }
-            val runner = interpreter.getSignatureRunner("int64_serving")
             val decoded = mutableListOf(startToken)
 
             repeat(MAX_OUTPUT_TOKENS) {
@@ -89,14 +88,15 @@ class TextEnhancer {
                 val outputs = HashMap<String, Any>()
                 outputs["logits"] = Array(1) { Array(decArr.size) { FloatArray(VOCAB_SIZE) } }
 
-                runner.run(
+                interpreter.runSignature(
                     mapOf(
                         "attention_mask" to arrayOf(attention),
                         "decoder_attention_mask" to arrayOf(decMask),
                         "decoder_input_ids" to arrayOf(decArr),
                         "input_ids" to arrayOf(inputIds)
                     ),
-                    outputs
+                    outputs,
+                    "int64_serving"
                 )
 
                 val logits = (outputs["logits"] as Array<Array<FloatArray>>)[0][decArr.size - 1]

--- a/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
+++ b/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
@@ -3,11 +3,12 @@ package info.ankurpandya.smartedittext
 import android.content.Context
 import android.util.Log
 import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.InterpreterApi
 import org.tensorflow.lite.flex.FlexDelegate
 import java.io.FileInputStream
-import java.nio.ByteBuffer
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -21,13 +22,16 @@ class TextEnhancer {
     private val IS_OFFLINE = false
 
     private lateinit var interpreter: Interpreter
-    private lateinit var outputBuffer: ByteBuffer
+    private lateinit var tokenizer: HuggingFaceTokenizer
+    private var startToken: Long = 0
+    private var endToken: Long = 0
     private var isInitialized = false
 
     companion object {
         private const val MODEL_FILE = "t5-small-dailycnn.tflite"
         private const val TOKENIZER_FILE = "tokenizer.json"
-        private const val OUTPUT_BUFFER_SIZE = 800
+        private const val MAX_OUTPUT_TOKENS = 32
+        private const val VOCAB_SIZE = 32128
     }
 
     fun init(context: Context) {
@@ -44,9 +48,11 @@ class TextEnhancer {
                         addDelegate(FlexDelegate())
                     }
                     interpreter = Interpreter(mapped, options)
-                    outputBuffer = ByteBuffer.allocateDirect(OUTPUT_BUFFER_SIZE)
-                    // Load tokenizer just to confirm asset is available
-                    context.assets.open(TOKENIZER_FILE).close()
+                    context.assets.open(TOKENIZER_FILE).use { stream ->
+                        tokenizer = HuggingFaceTokenizer.newInstance(stream, emptyMap())
+                    }
+                    startToken = tokenizer.encode("<pad>").ids.first().toLong()
+                    endToken = tokenizer.encode("</s>").ids.first().toLong()
                     isInitialized = true
                 }
             } catch (e: Exception) {
@@ -71,18 +77,42 @@ class TextEnhancer {
         }
 
         try {
-            outputBuffer.clear()
-            interpreter.run(originalText, outputBuffer)
-            outputBuffer.flip()
-            val bytes = ByteArray(outputBuffer.remaining())
-            outputBuffer.get(bytes)
-            outputBuffer.clear()
-            val result = String(bytes, Charsets.UTF_8).trim()
-            if (result.isNotEmpty()) {
-                onEnhanced.invoke(result)
-            } else {
-                onEnhanced.invoke(originalText)
+            val encoding = tokenizer.encode(originalText)
+            val inputIds = encoding.ids
+            val attention = LongArray(inputIds.size) { 1L }
+            val runner = interpreter.getSignatureRunner("int64_serving")
+            val decoded = mutableListOf(startToken)
+
+            repeat(MAX_OUTPUT_TOKENS) {
+                val decArr = decoded.toLongArray()
+                val decMask = LongArray(decArr.size) { 1L }
+                val outputs = HashMap<String, Any>()
+                outputs["logits"] = Array(1) { Array(decArr.size) { FloatArray(VOCAB_SIZE) } }
+
+                runner.run(
+                    mapOf(
+                        "attention_mask" to arrayOf(attention),
+                        "decoder_attention_mask" to arrayOf(decMask),
+                        "decoder_input_ids" to arrayOf(decArr),
+                        "input_ids" to arrayOf(inputIds)
+                    ),
+                    outputs
+                )
+
+                val logits = (outputs["logits"] as Array<Array<FloatArray>>)[0][decArr.size - 1]
+                var next = 0
+                var max = Float.NEGATIVE_INFINITY
+                for (i in logits.indices) {
+                    if (logits[i] > max) {
+                        max = logits[i]
+                        next = i
+                    }
+                }
+                if (next.toLong() == endToken) return onEnhanced(tokenizer.decode(decoded.drop(1).toLongArray()))
+                decoded.add(next.toLong())
             }
+            val result = tokenizer.decode(decoded.drop(1).toLongArray())
+            onEnhanced.invoke(result)
         } catch (e: Exception) {
             Log.e("TextEnhancer", "Offline inference failed: ${e.message}")
             onEnhanced.invoke(originalText)

--- a/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
+++ b/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
@@ -3,6 +3,7 @@ package info.ankurpandya.smartedittext
 import android.content.Context
 import android.util.Log
 import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.flex.FlexDelegate
 import java.io.FileInputStream
 import java.nio.ByteBuffer
 import java.nio.MappedByteBuffer
@@ -39,7 +40,10 @@ class TextEnhancer {
                         descriptor.startOffset,
                         descriptor.declaredLength
                     )
-                    interpreter = Interpreter(mapped)
+                    val options = Interpreter.Options().apply {
+                        addDelegate(FlexDelegate())
+                    }
+                    interpreter = Interpreter(mapped, options)
                     outputBuffer = ByteBuffer.allocateDirect(OUTPUT_BUFFER_SIZE)
                     // Load tokenizer just to confirm asset is available
                     context.assets.open(TOKENIZER_FILE).close()

--- a/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
+++ b/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
@@ -2,6 +2,11 @@ package info.ankurpandya.smartedittext
 
 import android.content.Context
 import android.util.Log
+import org.tensorflow.lite.Interpreter
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -14,9 +19,36 @@ class TextEnhancer {
 
     private val IS_OFFLINE = false
 
+    private lateinit var interpreter: Interpreter
+    private lateinit var outputBuffer: ByteBuffer
+    private var isInitialized = false
+
+    companion object {
+        private const val MODEL_FILE = "t5-small-dailycnn.tflite"
+        private const val TOKENIZER_FILE = "tokenizer.json"
+        private const val OUTPUT_BUFFER_SIZE = 800
+    }
+
     fun init(context: Context) {
         if (IS_OFFLINE) {
-
+            try {
+                val descriptor = context.assets.openFd(MODEL_FILE)
+                FileInputStream(descriptor.fileDescriptor).use { stream ->
+                    val mapped: MappedByteBuffer = stream.channel.map(
+                        FileChannel.MapMode.READ_ONLY,
+                        descriptor.startOffset,
+                        descriptor.declaredLength
+                    )
+                    interpreter = Interpreter(mapped)
+                    outputBuffer = ByteBuffer.allocateDirect(OUTPUT_BUFFER_SIZE)
+                    // Load tokenizer just to confirm asset is available
+                    context.assets.open(TOKENIZER_FILE).close()
+                    isInitialized = true
+                }
+            } catch (e: Exception) {
+                isInitialized = false
+                Log.e("TextEnhancer", "Offline init failed: ${e.message}")
+            }
         }
     }
 
@@ -29,7 +61,28 @@ class TextEnhancer {
     }
 
     private fun enhanceTextOffline(originalText: String, onEnhanced: (String) -> Unit) {
-        onEnhanced.invoke(originalText)
+        if (!isInitialized) {
+            onEnhanced.invoke(originalText)
+            return
+        }
+
+        try {
+            outputBuffer.clear()
+            interpreter.run(originalText, outputBuffer)
+            outputBuffer.flip()
+            val bytes = ByteArray(outputBuffer.remaining())
+            outputBuffer.get(bytes)
+            outputBuffer.clear()
+            val result = String(bytes, Charsets.UTF_8).trim()
+            if (result.isNotEmpty()) {
+                onEnhanced.invoke(result)
+            } else {
+                onEnhanced.invoke(originalText)
+            }
+        } catch (e: Exception) {
+            Log.e("TextEnhancer", "Offline inference failed: ${e.message}")
+            onEnhanced.invoke(originalText)
+        }
     }
 
     private fun enhanceTextOnline(originalText: String, onEnhanced: (String) -> Unit) {

--- a/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
+++ b/app/src/main/java/info/ankurpandya/smartedittext/TextEnhancer.kt
@@ -3,7 +3,6 @@ package info.ankurpandya.smartedittext
 import android.content.Context
 import android.util.Log
 import org.tensorflow.lite.Interpreter
-import org.tensorflow.lite.InterpreterApi
 import org.tensorflow.lite.flex.FlexDelegate
 import java.io.FileInputStream
 import java.nio.MappedByteBuffer
@@ -17,11 +16,17 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.io.IOException
 
-class TextEnhancer {
+class TextEnhancer(
+    var numThreads: Int = 2,
+    var currentDelegate: Int = DELEGATE_CPU,
+    private val listener: GeneratorListener? = null
+) {
 
     private val IS_OFFLINE = false
 
-    private lateinit var interpreter: Interpreter
+    private var context: Context? = null
+
+    private var interpreter: Interpreter? = null
     private lateinit var tokenizer: HuggingFaceTokenizer
     private var startToken: Long = 0
     private var endToken: Long = 0
@@ -32,33 +37,53 @@ class TextEnhancer {
         private const val TOKENIZER_FILE = "tokenizer.json"
         private const val MAX_OUTPUT_TOKENS = 32
         private const val VOCAB_SIZE = 32128
+
+        const val DELEGATE_CPU = 0
+        const val DELEGATE_GPU = 1
+        const val DELEGATE_NNAPI = 2
     }
 
     fun init(context: Context) {
+        this.context = context
         if (IS_OFFLINE) {
-            try {
-                val descriptor = context.assets.openFd(MODEL_FILE)
-                FileInputStream(descriptor.fileDescriptor).use { stream ->
-                    val mapped: MappedByteBuffer = stream.channel.map(
-                        FileChannel.MapMode.READ_ONLY,
-                        descriptor.startOffset,
-                        descriptor.declaredLength
-                    )
-                    val options = Interpreter.Options().apply {
-                        addDelegate(FlexDelegate())
+            setupTextGenerator()
+        }
+    }
+
+    fun clear() {
+        interpreter = null
+        isInitialized = false
+    }
+
+    private fun setupTextGenerator() {
+        val ctx = context ?: return
+        try {
+            val descriptor = ctx.assets.openFd(MODEL_FILE)
+            FileInputStream(descriptor.fileDescriptor).use { stream ->
+                val mapped: MappedByteBuffer = stream.channel.map(
+                    FileChannel.MapMode.READ_ONLY,
+                    descriptor.startOffset,
+                    descriptor.declaredLength
+                )
+                val options = Interpreter.Options().apply {
+                    setNumThreads(numThreads)
+                    addDelegate(FlexDelegate())
+                    when (currentDelegate) {
+                        DELEGATE_NNAPI -> setUseNNAPI(true)
                     }
-                    interpreter = Interpreter(mapped, options)
-                    context.assets.open(TOKENIZER_FILE).use { stream ->
-                        tokenizer = HuggingFaceTokenizer.newInstance(stream, emptyMap<String, Any>())
-                    }
-                    startToken = tokenizer.encode("<pad>").ids.first().toLong()
-                    endToken = tokenizer.encode("</s>").ids.first().toLong()
-                    isInitialized = true
                 }
-            } catch (e: Exception) {
-                isInitialized = false
-                Log.e("TextEnhancer", "Offline init failed: ${e.message}")
+                interpreter = Interpreter(mapped, options)
+                ctx.assets.open(TOKENIZER_FILE).use { stream ->
+                    tokenizer = HuggingFaceTokenizer.newInstance(stream, emptyMap<String, Any>())
+                }
+                startToken = tokenizer.encode("<pad>").ids.first().toLong()
+                endToken = tokenizer.encode("</s>").ids.first().toLong()
+                isInitialized = true
             }
+        } catch (e: Exception) {
+            clear()
+            listener?.onError("Offline init failed: ${e.message}")
+            Log.e("TextEnhancer", "Offline init failed: ${e.message}")
         }
     }
 
@@ -71,7 +96,8 @@ class TextEnhancer {
     }
 
     private fun enhanceTextOffline(originalText: String, onEnhanced: (String) -> Unit) {
-        if (!isInitialized) {
+        val intr = interpreter
+        if (!isInitialized || intr == null) {
             onEnhanced.invoke(originalText)
             return
         }
@@ -88,7 +114,7 @@ class TextEnhancer {
                 val outputs = HashMap<String, Any>()
                 outputs["logits"] = Array(1) { Array(decArr.size) { FloatArray(VOCAB_SIZE) } }
 
-                interpreter.runSignature(
+                intr.runSignature(
                     mapOf(
                         "attention_mask" to arrayOf(attention),
                         "decoder_attention_mask" to arrayOf(decMask),
@@ -152,4 +178,8 @@ class TextEnhancer {
             }
         })
     }
+}
+
+interface GeneratorListener {
+    fun onError(error: String)
 }


### PR DESCRIPTION
## Summary
- hook up t5-small-dailycnn offline model in `TextEnhancer`
- load tokenizer asset and run the interpreter
- return generated text when offline inference succeeds

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb4b38184832d834ae66a89b27041